### PR TITLE
Update bindgen to the latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ categories = ["embedded", "external-ffi-bindings"]
 cty = "0.2.1"
 
 [build-dependencies]
-bindgen = "0.56.0"
+bindgen = "0.63.0"


### PR DESCRIPTION
This allows us to use `cross build --target=arm-unknown-linux-gnueabihf` to cross-compile for older Raspberry Pi models or Raspberry Pi Zero.

The Docker image used by `cross` uses `BINDGEN_EXTRA_CLANG_ARGS_<TARGET>` env variables, which have been introduced in a version of `bindgen` newer than the one used by this library.